### PR TITLE
add line create cache folder to avoid exception

### DIFF
--- a/src/main/kotlin/provider/mcp.kt
+++ b/src/main/kotlin/provider/mcp.kt
@@ -173,7 +173,9 @@ fun downloadSrgMappings(minecraftVersion: String): Mappings {
 
 fun getMCPConfigMappings(minecraftVersion: String): Mappings {
     val cacheFolder = File("cache/")
-
+    if (!cacheFolder.exists()) {
+        cacheFolder.mkdirs()
+    }
     val obf2srgFile = File(cacheFolder, "mcpconfig-$minecraftVersion-joined.srg")
 
     if (!obf2srgFile.exists()) {


### PR DESCRIPTION
Running main.kt without manually create directory cache/ will lead to a File IO Exception - kotlin/java cannot create srg file directly when its parent directory does not exist.
Added a line to create the cache folder during the process if it is not exist.